### PR TITLE
fix(python): downgrade version to make it compatible with old rucio vers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Rucio policy package for the ESCAPE collaboration"
 readme="README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
    "Programming Language :: Python :: 3",
    "Operating System :: OS Independent",


### PR DESCRIPTION
Wanting to solve all the problems at the same time, we upgraded the required python version on the latest PR/release and now we have this error if we try to install the package on a greater Python version.
Our cluster also runs with python 3.9 :)

```
pip install escape-rucio-policy-package==0.2.0
ERROR: Ignored the following versions that require a different python version: 0.1.0 Requires-Python >=3.10; 0.2.0 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement escape-rucio-policy-package==0.2.0 (from versions: 0.0.1)
```

v0.2.1 should be released afterwards